### PR TITLE
fix: 哔哩发评反诈 功能类-检查评论自动点击后台等待

### DIFF
--- a/src/apps/icu.freedomIntrovert.biliSendCommAntifraud.ts
+++ b/src/apps/icu.freedomIntrovert.biliSendCommAntifraud.ts
@@ -10,8 +10,8 @@ export default defineGkdApp({
       rules: [
         {
           fastQuery: true,
-          activityIds:
-            'icu.freedomIntrovert.biliSendCommAntifraud.ByXposedLaunchedActivity',
+          actionDelay: 200, //150ms刚好 +50ms冗余，因为过早触发动画没加载完
+          activityIds: '.ByXposedLaunchedActivity',
           matches: 'Button[text="后台等待"][visibleToUser=true]',
           snapshotUrls: 'https://i.gkd.li/i/25240613',
         },


### PR DESCRIPTION
## 1.过早触发点击失败
### 2.另外bug：短时间内只能触发一次，第二次检查明明能查到可以手动执行选择器但是GKD没有动作，过了大约20s左右就可以又触发了但也是只有一次。规则没有限制，也排除开发者选项三个动画原因，所以说我怀疑是不是程序有问题。

https://github.com/user-attachments/assets/b79e21cf-f6b6-4d9d-a564-75b76bdc5106

