### PR TITLE
feat: 抖音 

### DIFF
--- a/src/apps/com.ss.android.ugc.aweme.ts
+++ b/src/apps/com.ss.android.ugc.aweme.ts
@@ -446,9 +446,10 @@ export default defineGkdApp({
       desc: '只展开一级评论，不点击展示更多',
       rules: [
         {
+          fastQuery: true,
           activityIds: '.detail.ui.DetailActivity',
           matches:
-            '[text!="展开更多"][text^="展开"][text$="条回复"][visibleToUser=true][childCount=0]',
+            '[text^="展开"][text$="条回复"][visibleToUser=true][childCount=0]',
           snapshotUrls: [
             'https://i.gkd.li/i/25356027',
             'https://i.gkd.li/i/25356355',


### PR DESCRIPTION
- 这里快速复制出来的为什么没有fastQuery，但是控件显示是支持的 https://i.gkd.li/i/25356027
<img width="1221" height="917" alt="图片" src="https://github.com/user-attachments/assets/10f78467-a539-4db4-8248-b9f3babaf2d4" />

- 这种展开不像b站只在一个角落(多几个少几个字位置会变)，有没有更好的办法？ https://i.gkd.li/i/25356546
<img width="391" height="112" alt="图片" src="https://github.com/user-attachments/assets/a07b6e48-7e86-458d-afd0-54b06eb847c2" />
