### PR TITLE
fix: 修复X主页推荐广告节点选择问题

### DIFF
--- a/src/apps/com.twitter.android.ts
+++ b/src/apps/com.twitter.android.ts
@@ -38,7 +38,7 @@ export default defineGkdApp({
         {
           key: 2,
           matches:
-            '[vid="tweet_curation_action"] - [vid="tweet_ad_badge_top_right"][visibleToUser=true]',
+            '@[vid="tweet_curation_action"] - [vid="tweet_ad_badge_top_right"][visibleToUser=true]',
           exampleUrls: 'https://e.gkd.li/705dd827-ff04-4233-af38-60d92439e1f3',
           snapshotUrls: 'https://i.gkd.li/i/24359526',
         },


### PR DESCRIPTION
应该点击右上角的三个点而不是ad badge