### PR TITLE
fix: 番茄小说 局部广告-阅读页面广告

### DIFF
--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -35,13 +35,14 @@ export default defineGkdApp({
           key: 1,
           fastQuery: true,
           matches:
-            '@ImageView[childCount=0][clickable=true][visibleToUser=true] - LinearLayout >(2,3) [text="广告" || text="立享优惠" || text*="查看" || text^="立即" || text$="参与"][text.length<5]',
+            '@ImageView[childCount=0][clickable=true][visibleToUser=true] - LinearLayout >(2,3) [text="广告" || text="立享优惠" || text*="查看" || text^="立即" || text*="参与"][text.length<5]',
           snapshotUrls: [
             'https://i.gkd.li/i/12908734',
             'https://i.gkd.li/i/14540281',
             'https://i.gkd.li/i/18138903',
             'https://i.gkd.li/i/21623147',
             'https://i.gkd.li/i/25174203',
+            'https://i.gkd.li/i/26347335',
           ],
         },
         {


### PR DESCRIPTION
现有的规则未能覆盖快照 https://i.gkd.li/i/26347335 中的“参与讨论”按钮