### PR TITLE
fix: 番茄小说 权限提示-通知权限

### DIFF
--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -327,7 +327,7 @@ export default defineGkdApp({
         },
         {
           key: 1, // 通知权限对话框可能多次触发 https://github.com/Lin-arm/GKD_subscription/pull/135
-          nmae: '小说阅读页', 
+          name: '小说阅读页', 
           activityIds: '.reader.ui.ReaderActivity',
           matches: [
             '[text="开启推送通知"][visibleToUser=true]',

--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -305,11 +305,11 @@ export default defineGkdApp({
       name: '权限提示-通知权限',
       desc: '点击"取消"',
       fastQuery: true,
-      matchTime: 10000,
-      actionMaximum: 1,
-      resetMatch: 'app',
       rules: [
         {
+          matchTime: 10000,
+          actionMaximum: 1,
+          resetMatch: 'app',
           activityIds: [
             '.widget.ConfirmDialogBuilder',
             '.pages.main.MainFragmentActivity',
@@ -322,6 +322,14 @@ export default defineGkdApp({
             'https://i.gkd.li/i/12716592',
             'https://i.gkd.li/i/21589667',
           ],
+        },
+        {
+          activityIds: '.reader.ui.ReaderActivity',
+          matches: [
+            '[text="开启推送通知"][visibleToUser=true]',
+            '[text="取消"][visibleToUser=true]',
+          ],
+          snapshotUrls: 'https://i.gkd.li/i/27190449',
         },
       ],
     },

--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -327,7 +327,7 @@ export default defineGkdApp({
         },
         {
           key: 1, // 通知权限对话框可能多次触发 https://github.com/Lin-arm/GKD_subscription/pull/135
-          name: '小说阅读页', 
+          name: '小说阅读页',
           activityIds: '.reader.ui.ReaderActivity',
           matches: [
             '[text="开启推送通知"][visibleToUser=true]',

--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -307,6 +307,8 @@ export default defineGkdApp({
       fastQuery: true,
       rules: [
         {
+          key: 0,
+          name: '首页',
           matchTime: 10000,
           actionMaximum: 1,
           resetMatch: 'app',
@@ -324,6 +326,8 @@ export default defineGkdApp({
           ],
         },
         {
+          key: 1, // 通知权限对话框可能多次触发 https://github.com/Lin-arm/GKD_subscription/pull/135
+          nmae: '小说阅读页', 
           activityIds: '.reader.ui.ReaderActivity',
           matches: [
             '[text="开启推送通知"][visibleToUser=true]',


### PR DESCRIPTION
现有的规则无法处理在阅读界面点击催更或打赏后弹出的通知权限对话框。

阅读界面与原规则的 `activityIds` 均不同，且原规则对 `matchTime`、`actionMaximum` 字段做了配置。考虑到通知权限对话框可能多次触发，且大概率会在打开APP10秒以后才出现，为保持兼容性，故新建了一条规则，将原规则的字段由规则组全局移动到单条规则内。