### PR TITLE
feat: 增加瑞幸咖啡和微信广告规则

### DIFF
--- a/src/apps/com.lucky.luckyclient.ts
+++ b/src/apps/com.lucky.luckyclient.ts
@@ -45,5 +45,20 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 4,
+      name: '全屏广告-添加瑞幸幸运官',
+      desc: '匹配93x93关闭按钮，点击后执行返回键关闭添加瑞幸幸运官弹窗',
+      matchTime: 15000,
+      actionMaximum: 1,
+      rules: [
+        {
+          activityIds: 'com.lucky.luckincoffee.MainActivity',
+          matches:
+            '@Image[width=93][height=93][visibleToUser=true] <<n [vid="webview_dialog"]',
+          action: 'back',
+        },
+      ],
+    },
   ],
 });

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -68,6 +68,7 @@ export default defineGkdApp({
             '@LinearLayout[clickable=true] > [text="关闭该广告" || text*="Close"][visibleToUser=true]', //2
             '@LinearLayout[index=1][clickable=true] <2 * < * - [text*="广告"]', //3
             '@[text="关闭该广告"] -2 [text^="对这条广告不感兴趣"][visibleToUser=true]', //4
+            '[text="直接关闭"][clickable=true][visibleToUser=true]', //5
           ],
           snapshotUrls: [
             //1
@@ -84,6 +85,8 @@ export default defineGkdApp({
             'https://i.gkd.li/i/19666176',
             //4
             'https://i.gkd.li/i/19633486',
+            //5
+            'https://i.gkd.li/i/28643685',
           ],
         },
 


### PR DESCRIPTION
## 概述
本 PR 包含两个订阅规则更新：

1. **瑞幸咖啡** - 新增"全屏广告-添加瑞幸幸运官"规则
2. **微信** - 朋友圈广告新机制适配

## 变更内容

### 瑞幸咖啡 (com.lucky.luckyclient)
- 在 `key: 4` 新增"全屏广告-添加瑞幸幸运官"规则
- 匹配 93x93 关闭按钮（`@Image[width=93][height=93]`）以及 `webview_dialog`
- 点击后通过返回键关闭添加瑞幸幸运官弹窗

### 微信 (com.tencent.mm)
- 在朋友圈广告 `key: 25`（点击[关闭]）的 `anyMatches` 中新增分支 `//5`
- 新分支匹配 `[text="直接关闭"][clickable=true][visibleToUser=true]`
- 适配微信朋友圈广告新机制弹出的"关闭该广告的原因"对话框，可直接关闭广告
- 配套新增快照 `https://i.gkd.li/i/28643685`

## 测试
- 瑞幸咖啡：进入触发"添加瑞幸幸运官"弹窗的页面，验证规则能自动点击关闭按钮并执行返回键
- 微信：进入朋友圈广告页面，验证新弹窗出现时规则能自动点击"直接关闭"按钮