### PR TITLE
feat: 瑞幸咖啡 全屏广告-添加瑞幸幸运官

### DIFF
--- a/src/apps/com.lucky.luckyclient.ts
+++ b/src/apps/com.lucky.luckyclient.ts
@@ -45,5 +45,20 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 4,
+      name: '全屏广告-添加瑞幸幸运官',
+      desc: '匹配93x93关闭按钮，点击后执行返回键关闭添加瑞幸幸运官弹窗',
+      matchTime: 15000,
+      actionMaximum: 1,
+      rules: [
+        {
+          activityIds: 'com.lucky.luckincoffee.MainActivity',
+          matches:
+            '@Image[width=93][height=93][visibleToUser=true] <<n [vid="webview_dialog"]',
+          action: 'back',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
瑞幸打开时可能会出现“添加瑞幸幸运官”样式的弹窗，现有的规则无法屏蔽。新增规则检测X按钮，检测到会执行一次返回操作来跳过该弹窗