### PR TITLE
feat: 微信 分段广告-朋友圈广告-适配新机制

### DIFF
--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -86,7 +86,7 @@ export default defineGkdApp({
             //4
             'https://i.gkd.li/i/19633486',
             //5
-            'https://i.gkd.li/i/28643685',
+            'https://i.gkd.li/i/28643685', // 疑似 微信v8.0.72 将第三段改到了第二段
           ],
         },
 

--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -68,6 +68,7 @@ export default defineGkdApp({
             '@LinearLayout[clickable=true] > [text="关闭该广告" || text*="Close"][visibleToUser=true]', //2
             '@LinearLayout[index=1][clickable=true] <2 * < * - [text*="广告"]', //3
             '@[text="关闭该广告"] -2 [text^="对这条广告不感兴趣"][visibleToUser=true]', //4
+            '[text="直接关闭"][clickable=true][visibleToUser=true]', //5
           ],
           snapshotUrls: [
             //1
@@ -84,6 +85,8 @@ export default defineGkdApp({
             'https://i.gkd.li/i/19666176',
             //4
             'https://i.gkd.li/i/19633486',
+            //5
+            'https://i.gkd.li/i/28643685',
           ],
         },
 


### PR DESCRIPTION
微信的朋友圈广告关闭机制有所更新，现在需要点击“直接关闭”按钮。原有的机制暂时保留，只是新增了“直接关闭”