### PR TITLE
fix: 微信 分段广告-朋友圈广告-适配新机制 微信v8.0.72

### DIFF
--- a/src/apps/com.tencent.mm.ts
+++ b/src/apps/com.tencent.mm.ts
@@ -68,7 +68,6 @@ export default defineGkdApp({
             '@LinearLayout[clickable=true] > [text="关闭该广告" || text*="Close"][visibleToUser=true]', //2
             '@LinearLayout[index=1][clickable=true] <2 * < * - [text*="广告"]', //3
             '@[text="关闭该广告"] -2 [text^="对这条广告不感兴趣"][visibleToUser=true]', //4
-            '[text="直接关闭"][clickable=true][visibleToUser=true]', //5
           ],
           snapshotUrls: [
             //1
@@ -85,8 +84,6 @@ export default defineGkdApp({
             'https://i.gkd.li/i/19666176',
             //4
             'https://i.gkd.li/i/19633486',
-            //5
-            'https://i.gkd.li/i/28643685', // 疑似 微信v8.0.72 将第三段改到了第二段
           ],
         },
 
@@ -96,12 +93,18 @@ export default defineGkdApp({
           preKeys: [25],
           key: 50,
           name: '点击[关闭]',
-          matches: '[text*="关闭" || text="Close"][clickable=true]',
+          anyMatches: [
+            '[text*="关闭" || text="Close"][clickable=true]', //1
+            '[text="直接关闭"][clickable=true][visibleToUser=true]', //2
+          ],
           snapshotUrls: [
+            //1
             'https://i.gkd.li/i/12663984',
             'https://i.gkd.li/i/12905846',
             'https://i.gkd.li/i/14647940',
             'https://i.gkd.li/i/14783534',
+            //2
+            'https://i.gkd.li/i/28643685', // 微信v8.0.72 引入"直接关闭"按钮
           ],
         },
 


### PR DESCRIPTION
抱歉昨天的修改有误，微信v8.0.72新机制的广告关闭流程是
key 0/1/2  命中"广告"标签 → 点击
   ↓
key 25     命中"关闭该广告" → 点击
   ↓
key 50     命中"直接关闭" → 点击（新增 //2 分支）
   ↓
广告关闭
因此把昨天增加的规则从key25移到了key50，这次从本地实测了一下是OK的