### PR TITLE
feat: Edge 功能类-下载确认

### DIFF
--- a/src/apps/com.microsoft.emmx.ts
+++ b/src/apps/com.microsoft.emmx.ts
@@ -105,5 +105,16 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 9,
+      name: '功能类-下载确认',
+      desc: '自动点击下载弹窗中的下载按钮',
+      fastQuery: true,
+      rules: [
+        {
+          matches: '[vid="button1"]',
+        },
+      ],
+    },
   ],
 });

--- a/src/apps/com.microsoft.emmx.ts
+++ b/src/apps/com.microsoft.emmx.ts
@@ -113,6 +113,8 @@ export default defineGkdApp({
       rules: [
         {
           matches: '[vid="button1"]',
+          snapshotUrls: 'https://i.gkd.li/i/30865007',
+          exampleUrls: 'https://e.gkd.li/df8b81cd-1bfa-402a-a317-610f9d713674',
         },
       ],
     },

--- a/src/apps/com.microsoft.emmx.ts
+++ b/src/apps/com.microsoft.emmx.ts
@@ -112,7 +112,8 @@ export default defineGkdApp({
       fastQuery: true,
       rules: [
         {
-          matches: '[vid="button1"]',
+          matches:
+            '[text*="下载" || text*="下載"][visibleToUser=true] +2 [childCount=3] > [vid="button1"]',
           snapshotUrls: 'https://i.gkd.li/i/30865007',
           exampleUrls: 'https://e.gkd.li/df8b81cd-1bfa-402a-a317-610f9d713674',
         },


### PR DESCRIPTION
自动点击 Edge 下载确认弹窗中的「下载」按钮

- 选择器: `[vid="button1"]`（文案随文件变化，只用 vid）
- 快照: https://i.gkd.li/i/30865007
- 示例: https://e.gkd.li/df8b81cd-1bfa-402a-a317-610f9d713674