### PR TITLE
feat: Via 功能类-下载确认

### DIFF
--- a/src/apps/mark.via.ts
+++ b/src/apps/mark.via.ts
@@ -12,7 +12,8 @@ export default defineGkdApp({
       rules: [
         {
           activityIds: 'mark.via.Shell',
-          matches: '[vid="ed"]',
+          matches: '[vid="ed" || vid="eo"]',
+          snapshotUrls: 'https://i.gkd.li/i/30865110',
         },
       ],
     },

--- a/src/apps/mark.via.ts
+++ b/src/apps/mark.via.ts
@@ -7,6 +7,7 @@ export default defineGkdApp({
     {
       key: 1,
       name: '功能类-下载确认',
+      desc: '自动点击下载弹窗中的确定按钮',
       fastQuery: true,
       rules: [
         {

--- a/src/apps/mark.via.ts
+++ b/src/apps/mark.via.ts
@@ -1,0 +1,19 @@
+import { defineGkdApp } from '@gkd-kit/define';
+
+export default defineGkdApp({
+  id: 'mark.via',
+  name: 'Via',
+  groups: [
+    {
+      key: 1,
+      name: '功能类-下载确认',
+      fastQuery: true,
+      rules: [
+        {
+          activityIds: 'mark.via.Shell',
+          matches: '[vid="ed"][text="确定"][clickable=true]',
+        },
+      ],
+    },
+  ],
+});

--- a/src/apps/mark.via.ts
+++ b/src/apps/mark.via.ts
@@ -6,14 +6,21 @@ export default defineGkdApp({
   groups: [
     {
       key: 1,
-      name: '功能类-下载确认',
-      desc: '自动点击下载弹窗中的确定按钮',
-      fastQuery: true,
+      name: '功能类-自动[确认]下载',
+      desc: '自动点击下载弹窗中的[确定]按钮',
       rules: [
         {
-          activityIds: 'mark.via.Shell',
-          matches: '[vid="ed" || vid="eo"]',
-          snapshotUrls: 'https://i.gkd.li/i/30865110',
+          fastQuery: true,
+          activityIds: '.Shell',
+          matches:
+            '@[text="确定" || text="確定" || text="OK"] -n [text*="下载" || text*="下載" || text*="download"][visibleToUser=true]',
+          snapshotUrls: [
+            'https://i.gkd.li/i/30865110', //确定
+            'https://i.gkd.li/i/30867153', //确定
+            'https://i.gkd.li/i/30867205', //確定
+            'https://i.gkd.li/i/30867206', //OK
+          ],
+          exampleUrls: 'https://e.gkd.li/2f2ef3bf-019d-4936-bbd8-51ba4cbe698c',
         },
       ],
     },

--- a/src/apps/mark.via.ts
+++ b/src/apps/mark.via.ts
@@ -12,7 +12,7 @@ export default defineGkdApp({
       rules: [
         {
           activityIds: 'mark.via.Shell',
-          matches: '[vid="ed"][text="确定"][clickable=true]',
+          matches: '[vid="ed"]',
         },
       ],
     },


### PR DESCRIPTION
自动点击 Via 下载确认弹窗中的「确定」按钮

- 选择器: `[vid="ed" || vid="eo"]`（兼容 5.4.1 / 6.5.1）
- 快照: https://i.gkd.li/i/30865110