### PR TITLE
fix: 番茄免费小说 局部广告-首页右侧悬浮广告&分段广告-阅读页面广告

### DIFF
--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -51,17 +51,26 @@ export default defineGkdApp({
             '.pages.main.MainFragmentActivity',
             '.ad.openingscreenad.OpeningScreenADActivity',
           ],
-          matches: [
+          matches:
             '@ImageView[clickable=true][childCount=0][index=0][visibleToUser=true] < [childCount=3] < RelativeLayout < FrameLayout <2 [id="android:id/content"][childCount=3]',
-            '@ImageView[desc="Close Button"] <2 View < View < View < View < ComposeView < [id="android:id/content"]',
-            '@ImageView[clickable=true] + ViewGroup[vid="root_view"] > [text="立即领取"]',
-          ]
           snapshotUrls: [
             'https://i.gkd.li/i/12716506',
             'https://i.gkd.li/i/13318796',
-            'https://i.gkd.li/i/28907537',
-            'https://i.gkd.li/i/31327606',
           ],
+        },
+        {
+          key: 1,
+          activityIds: '.pages.main.MainFragmentActivity',
+          matches:
+            '@ImageView[desc="Close Button"] <2 View < View < View < View < ComposeView < [id="android:id/content"]',
+          snapshotUrls: 'https://i.gkd.li/i/28907537',
+        },
+        {
+          key: 2,
+          activityIds: '.pages.main.MainFragmentActivity',
+          matches:
+            '@ImageView[clickable=true] + ViewGroup[vid="root_view"] > [text="立即领取"]',
+          snapshotUrls: 'https://i.gkd.li/i/31327606',
         },
       ],
     },

--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -187,7 +187,7 @@ export default defineGkdApp({
         {
           key: 0,
           matches:
-            '@[(name$="ImageView" || getChild(0).name$="ImageView") && desc!="back_unfold"][clickable=true][visibleToUser=true][width<102 && height<102] <n [childCount>1] >(2,3) [text*="查看" || text$="优惠" || text^="立即" || text^="马上" || text*="参与" || text*="免费" || (text*="领" && text*="券") || (text*="返" && text*="金币")][text.length<10]',
+            '@[(name$="ImageView" || getChild(0).name$="ImageView") && desc!="back_unfold"][clickable=true][visibleToUser=true][width<102 && height<102] <n [childCount>1] >(2,3) [text*="查看" || text$="优惠" || text^="立即" || text^="马上" || text*="参与" || text*="参加" || text*="免费" || (text*="领" && text*="券") || (text*="返" && text*="金币")][text.length<10]',
           snapshotUrls: [
             'https://i.gkd.li/i/12908734', // 查看详情
             'https://i.gkd.li/i/18138903', // 立享优惠
@@ -199,6 +199,7 @@ export default defineGkdApp({
             'https://i.gkd.li/i/24706223', // 免费观看
             'https://i.gkd.li/i/14548657', // 返1098金币
             'https://i.gkd.li/i/14810480', // 返780金币
+            'https://i.gkd.li/i/31328323', // 我要参加
           ],
           excludeSnapshotUrls: [
             'https://i.gkd.li/i/28821485', // 用 [name$="ImageView" || getChild(0).name$="ImageView"][visibleToUser=false] 排除

--- a/src/apps/com.dragon.read.ts
+++ b/src/apps/com.dragon.read.ts
@@ -51,19 +51,17 @@ export default defineGkdApp({
             '.pages.main.MainFragmentActivity',
             '.ad.openingscreenad.OpeningScreenADActivity',
           ],
-          matches:
+          matches: [
             '@ImageView[clickable=true][childCount=0][index=0][visibleToUser=true] < [childCount=3] < RelativeLayout < FrameLayout <2 [id="android:id/content"][childCount=3]',
+            '@ImageView[desc="Close Button"] <2 View < View < View < View < ComposeView < [id="android:id/content"]',
+            '@ImageView[clickable=true] + ViewGroup[vid="root_view"] > [text="立即领取"]',
+          ]
           snapshotUrls: [
             'https://i.gkd.li/i/12716506',
             'https://i.gkd.li/i/13318796',
+            'https://i.gkd.li/i/28907537',
+            'https://i.gkd.li/i/31327606',
           ],
-        },
-        {
-          key: 1,
-          activityIds: '.pages.main.MainFragmentActivity',
-          matches:
-            '@ImageView[desc="Close Button"] <2 View < View < View < View < ComposeView < [id="android:id/content"]',
-          snapshotUrls: 'https://i.gkd.li/i/28907537',
         },
       ],
     },


### PR DESCRIPTION
- 适配新版悬浮广告关闭按钮
- 补充阅读页面广告case
已复现并测试规则正确工作 `_(:3 」∠ )_`